### PR TITLE
fix. github action 빌드 실패: node 버전 변경(20 -> 24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: onejay-lab/package-lock.json
 


### PR DESCRIPTION
## 내용
- Github Action Build 실패
- deploy.yml 의 노드 버전 업데이트

```text

Run npm run build

> onejay-lab@0.0.1 build
> astro build

Node.js v20.20.1 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"

GitHub Actions CI Environment Detected!
Additional steps may be needed to set your Node.js version:
Documentation: https://docs.astro.build/en/guides/deploy/

Error: Process completed with exit code 1.
````

```text
[build](https://github.com/jay2u8809/jay2u8809.github.io/actions/runs/23176122219/job/67338540422#step:15:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/configure-pages@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see:
```